### PR TITLE
Fix/wrong commad

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -66,7 +66,7 @@ void		set_commands(t_cmds *cmds);
 void		free_commands(t_cmds *cmds);
 
 /* Commands */
-int			echo_adapter(const char *arg);
+int			echo_adapter(const char *args);
 int			pwd_adapter(const char *arg);
 int			exit_adapter(const char *arg);
 void		execute_cmd(t_cmds *cmds);

--- a/srcs/commands.c
+++ b/srcs/commands.c
@@ -21,7 +21,8 @@ Command local_commands[] = {
 
 void	execute_cmd(t_cmds *cmds)
 {
-	if (cmds->cmd_finded->name) {
+	if (cmds->cmd_finded->name)
+	{
 		cmds->exit_code.last_cmd = cmds->input->cmd_name;
 		cmds->exit_code.code = cmds->cmd_finded->execute(cmds->input->cmd_args);
 	}

--- a/srcs/commands.c
+++ b/srcs/commands.c
@@ -21,8 +21,10 @@ Command local_commands[] = {
 
 void	execute_cmd(t_cmds *cmds)
 {
-	cmds->exit_code.last_cmd = cmds->input->cmd_name;
-	cmds->exit_code.code = cmds->cmd_finded->execute(cmds->input->cmd_args);
+	if (cmds->cmd_finded->name) {
+		cmds->exit_code.last_cmd = cmds->input->cmd_name;
+		cmds->exit_code.code = cmds->cmd_finded->execute(cmds->input->cmd_args);
+	}
 }
 
 void	set_commands(t_cmds *cmds)

--- a/srcs/commands/echo.c
+++ b/srcs/commands/echo.c
@@ -12,8 +12,53 @@
 
 #include "../../includes/minishell.h"
 
-int	echo_adapter(const char *arg)
+void	free_args(char **args)
 {
-	ft_printf("%s\n", arg);
+	int	i;
+
+	i = 0;
+	while (args[i] != NULL)
+	{
+		free(args[i]);
+		i++;
+	}
+	free(args);
+}
+
+void	print_args(char **args)
+{
+	int	i;
+
+	i = 0;
+	while (args[i] != NULL)
+	{
+		ft_printf("%s ", args[i]);
+		i++;
+	}
+}
+
+int	echo_adapter(const char *args)
+{
+	char	**words;
+	int		i;
+	int		trigger;
+
+	trigger = 0;
+	if (args == NULL)
+	{
+		ft_printf("\n");
+		return (0);
+	}
+	words = ft_split(args, ' ');
+	i = 0;
+	if (ft_strcmp(words[0], "-n") == 0)
+	{
+		i = 1;
+		trigger = 1;
+	}
+	print_args(words + i);
+	if (trigger == 0)
+		ft_printf("\n");
+	free_args(words);
 	return (0);
 }

--- a/srcs/input.c
+++ b/srcs/input.c
@@ -22,9 +22,12 @@ void	find_command(t_cmds *cmds)
 		if (ft_strcmp(cmds->arr_cmds[i].name, cmds->input->cmd_name) == 0)
 		{
 			ft_memcpy(cmds->cmd_finded, &cmds->arr_cmds[i], sizeof(t_command));
+			return ;
 		}
 		i++;
 	}
+	ft_printf("minishell: %s: command not found\n", cmds->input->cmd_name);
+	cmds->cmd_finded->name = NULL;
 }
 
 void	read_keyboard(t_cmds *cmds)


### PR DESCRIPTION
This PR implements a check if command founded or not, if not found show message error and clean `cmds->cmd_finded->name = NULL;`