### PR TITLE
fix: removed free in array commands

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -14,14 +14,6 @@
 
 void	free_commands(t_cmds *cmds)
 {
-	size_t	i;
-
-	i = 0;
-	while (i < cmds->num_cmds)
-	{
-		free(cmds->arr_cmds[i].name);
-		i++;
-	}
 	free(cmds->arr_cmds);
 	free(cmds->cmd_finded);
 	free(cmds->input);


### PR DESCRIPTION
    void	free_commands(t_cmds *cmds)
    {
	    free(cmds->arr_cmds);
	    free(cmds->cmd_finded);
	    free(cmds->input);
	    free(cmds);
    }