### PR TITLE
fix: solve segment fault caling cmds.list

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -38,7 +38,8 @@ void	check_args(int argc, char **argv)
 
 int	minishell(t_cmds *cmds)
 {
-	int	exit_code;
+	int			exit_code;
+	t_cmd_node	*actual_cmd;
 
 	signals_handler();
 	while (1)
@@ -49,7 +50,11 @@ int	minishell(t_cmds *cmds)
 		token_analysis(cmds);
 		syntax_analysis(cmds);
 		find_command(cmds);
+		actual_cmd = cmds->cmd_list;
+		while (actual_cmd != NULL)
+			actual_cmd = actual_cmd->next;
 		execute_cmd(cmds);
+		free_cmd_nodes(cmds->cmd_list);
 		exit_code = cmds->exit_code.code;
 		if (is_exit(cmds))
 			break ;

--- a/srcs/parser/token_analysis.c
+++ b/srcs/parser/token_analysis.c
@@ -109,7 +109,6 @@ int	token_analysis(t_cmds *cmds)
 	classify_tk_nodes(list_tokens);
 	concat_tk_nodes(cmds, list_tokens);
 	build_struct_to_exec(cmds, list_tokens);
-	free_cmd_nodes(cmds->cmd_list);
 	free_tk_nodes(list_tokens);
 	free(data_copy);
 	return (1);


### PR DESCRIPTION
fix segment fault when call linked list cmds->list

Problem happend because free running before execute