### PR TITLE
Refactor export env and cosmect prompt

### DIFF
--- a/srcs/commands/export.c
+++ b/srcs/commands/export.c
@@ -6,24 +6,59 @@
 /*   By: caalbert <caalbert@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/04 21:16:46 by caalbert          #+#    #+#             */
-/*   Updated: 2023/06/08 20:04:29 by caalbert         ###   ########.fr       */
+/*   Updated: 2023/07/01 20:59:06 by caalbert         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-int	export_adapter(t_cmds *cmds)
+// int	export_adapter(t_cmds *cmds)
+// {
+// 	char	*var_name;
+// 	char	*var_value;
+
+// 	var_name = NULL;
+// 	var_value = NULL;
+// 	if (cmds->input->cmd_args[1] != '\0')
+// 	{
+// 		var_name = &cmds->input->cmd_args[1];
+// 		var_value = &cmds->input->cmd_args[2];
+// 		if (setenv(var_name, var_value, 1) != 0)
+// 		{
+// 			perror("Error to export var");
+// 			return (1);
+// 		}
+// 	}
+// 	else
+// 		return (1);
+// 	return (0);
+// }
+
+static void	free_args(char **args)
+{
+	int	i;
+
+	i = 0;
+	while (args[i] != NULL)
+	{
+		free(args[i]);
+		i++;
+	}
+	free(args);
+}
+
+int	set_env_var(char **args)
 {
 	char	*var_name;
 	char	*var_value;
+	int		result;
 
-	var_name = NULL;
-	var_value = NULL;
-	if (cmds->input->cmd_args[1] != '\0')
+	var_name = ft_strtok(args[0], "=", 0);
+	var_value = ft_strtok(NULL, "=", 0);
+	if (var_name && var_value)
 	{
-		var_name = &cmds->input->cmd_args[1];
-		var_value = &cmds->input->cmd_args[2];
-		if (setenv(var_name, var_value, 1) != 0)
+		result = setenv(var_name, var_value, 1);
+		if (result != 0)
 		{
 			perror("Error to export var");
 			return (1);
@@ -32,4 +67,26 @@ int	export_adapter(t_cmds *cmds)
 	else
 		return (1);
 	return (0);
+}
+
+int	export_adapter(t_cmds *cmds)
+{
+	char	**args;
+	char	**env;
+	int		result;
+
+	env = cmds->envs;
+	if (cmds->input->cmd_args == NULL)
+	{
+		while (*env)
+		{
+			printf("%s\n", *env);
+			env++;
+		}
+		return (0);
+	}
+	args = ft_split(cmds->input->cmd_args, ' ');
+	result = set_env_var(args);
+	free_args(args);
+	return (result);
 }

--- a/srcs/input.c
+++ b/srcs/input.c
@@ -6,7 +6,7 @@
 /*   By: caalbert <caalbert@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/18 02:55:02 by antthoma          #+#    #+#             */
-/*   Updated: 2023/06/03 22:56:19 by caalbert         ###   ########.fr       */
+/*   Updated: 2023/07/01 18:39:45 by caalbert         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ void	find_command(t_cmds *cmds)
 
 void	read_keyboard(t_cmds *cmds)
 {
-	ft_printf("> ");
+	ft_printf("\033[0;32mminishell: > \033[0;0m");
 	fgets(cmds->input->data, sizeof(cmds->input->data), stdin);
 	cmds->input->data[strcspn(cmds->input->data, "\n")] = 0;
 	if (cmds->input->data[0] == '\0')


### PR DESCRIPTION
This PR was necessary to refactor the first version of export built-in. In  this version I add same behavior of bash, when typed the command [export] it`s return the hoke path env content. Another inplemente is about prompt, now the symbol prompt is in greeen and has a minishel title in the line. Like this:

<img width="404" alt="Captura de Tela 2023-07-01 às 21 13 21" src="https://github.com/tonnytg/42_minishell/assets/3737837/b6374734-c2b8-4a56-9c58-12215f93fff6">

This feature is about UX in prompt.

