### PR TITLE
fix: parse exit -

### DIFF
--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -28,7 +28,7 @@ int	count_args(const char *arg)
 	return (count + 1);
 }
 
-int	check_erros_exit(const char *arg, int count)
+int	check_errors_exit(const char *arg, int count)
 {
 	if (count > 1)
 	{
@@ -42,6 +42,11 @@ int	check_erros_exit(const char *arg, int count)
 	}
 	if (arg[0] == '-' && ft_isdigit(arg[1]) == 1)
 		return (ft_atoi(arg));
+	if (arg[0] == '-' && arg[1] == '\0')
+	{
+		ft_printf("minishell: exit: %s: numeric argument required\n", arg);
+		return (2);
+	}
 	if (arg != NULL)
 		return (ft_atoi(arg));
 	return (0);
@@ -58,7 +63,7 @@ int	exit_adapter(t_cmds *cmds)
 		return (0);
 	count = 0;
 	count = count_args(cmds->input->cmd_args);
-	exit_code = check_erros_exit(cmds->input->cmd_args, count);
+	exit_code = check_errors_exit(cmds->input->cmd_args, count);
 	exit_code = (exit_code % 256 + 256) % 256;
 	cmds->exit_code.code = exit_code;
 	return (exit_code);


### PR DESCRIPTION
- [x]  -  → return is 2
- [x]  2 → return is 2
- [x]  a → return is 2
- [x]  -1 → return is 255
- [x]  -20000000000 → return is 0
- [x]  20000000000 → return is 0
- [x]  asdfadsfasdfasfas → return is 2
- [ ]  $PWD → convert to /app → execute string → return must be number
- [x]  → return is 0