### PR TITLE
Feat/regua return value of a process

### DIFF
--- a/srcs/commands/exec_builtin_cmd.c
+++ b/srcs/commands/exec_builtin_cmd.c
@@ -43,15 +43,22 @@ void	define_cmd_to_exec(t_cmds *cmds)
 	}
 }
 
+int	skip_commands_child(t_cmds *cmds)
+{
+	if (ft_strcmp(cmds->current->cmd_name, "exit") == 0)
+		return (1);
+	else if (ft_strcmp(cmds->current->cmd_name, "cd") == 0)
+		return (1);
+	return (0);
+}
+
 void	exec_builtin(t_cmds *cmds)
 {
 	pid_t	pid;
 	int		child_return_status;
 
 	define_cmd_to_exec(cmds);
-	if (ft_strcmp(cmds->current->cmd_name, "exit") == 0)
-		cmds->current->cmd_builtin->execute(cmds);
-	else if (ft_strcmp(cmds->current->cmd_name, "cd") == 0)
+	if (skip_commands_child(cmds) == 1)
 		cmds->current->cmd_builtin->execute(cmds);
 	else
 	{
@@ -64,8 +71,9 @@ void	exec_builtin(t_cmds *cmds)
 		else if (pid == 0)
 		{
 			cmds->current->cmd_builtin->execute(cmds);
+			child_return_status = cmds->exit_code.code;
 			free_builtin_cmd(cmds);
-			exit(cmds->exit_code.code);
+			exit(child_return_status);
 		}
 		else
 			waitpid(pid, &child_return_status, 0);

--- a/srcs/commands/exec_builtin_cmd.c
+++ b/srcs/commands/exec_builtin_cmd.c
@@ -65,9 +65,10 @@ void	exec_builtin(t_cmds *cmds)
 		{
 			cmds->current->cmd_builtin->execute(cmds);
 			free_builtin_cmd(cmds);
-			exit(EXIT_SUCCESS);
+			exit(cmds->exit_code.code);
 		}
 		else
 			waitpid(pid, &child_return_status, 0);
+		cmds->exit_code.code = WEXITSTATUS(child_return_status);
 	}
 }

--- a/srcs/commands/exec_external_cmd.c
+++ b/srcs/commands/exec_external_cmd.c
@@ -16,7 +16,9 @@ void	exec_external(t_cmds *cmds)
 {
 	pid_t	pid;
 	char	*path;
+	int		child_return_status;
 
+	cmds->exit_code.code = 0;
 	if (ft_strcmp(cmds->current->type, "WORD") == 0)
 	{
 		path = get_fullpath(cmds);
@@ -30,8 +32,9 @@ void	exec_external(t_cmds *cmds)
 			perror("execve");
 		}
 		if (pid > 0)
-			waitpid(pid, NULL, 0);
+			waitpid(pid, &child_return_status, 0);
 		free(path);
 	}
 	free_split(cmds->current->split_args);
+	cmds->exit_code.code = WEXITSTATUS(child_return_status);
 }

--- a/srcs/commands/nodes.c
+++ b/srcs/commands/nodes.c
@@ -41,6 +41,9 @@ void	run_node(t_cmds *cmds)
 		else if (type_command == 1)
 			exec_external(cmds);
 		else
+		{
 			printf("minishell: %s: command not found\n", cmds->input->cmd_name);
+			cmds->exit_code.code = 127;
+		}
 	}
 }


### PR DESCRIPTION
use same variable `	int		child_return_status;` to receive value `child_return_status = cmds->exit_code.code;`
return in process `exit(child_return_status);`

With this you can resgate exit status code without leak |
`cmds->exit_code.code = WEXITSTATUS(child_return_status);`