### PR TITLE
feat: fix all leaks and expr 0 + 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ FILES	= \
 			srcs/read_keyboard/input.c				\
 			srcs/read_keyboard/check_data_input.c	\
 			srcs/commands/commands.c				\
+			srcs/commands/interpreter.c				\
 			srcs/commands/nodes.c					\
 			srcs/commands/path.c					\
 			srcs/commands/type_commands.c 			\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -57,6 +57,7 @@ typedef struct s_cmd_node
 {
 	char				*phrase;
 	char				*phrase_temp;
+	char				**phrase_parsed;
 	char				*cmd_name;
 	char				*full_args;
 	char				**split_args;
@@ -147,6 +148,9 @@ int			export_adapter(t_cmds *cmds);
 void		execute_cmd(t_cmds *cmds);
 void		set_commands(t_cmds *cmds);
 void		free_commands(t_cmds *cmds);
+
+/* Commands */
+void		init_interpreter(t_cmds *cmds);
 
 /* Command Echo echo_utils.c */
 void		echo_print_envs(char *word);

--- a/srcs/builtins/echo.c
+++ b/srcs/builtins/echo.c
@@ -84,7 +84,7 @@ int	echo_adapter(t_cmds *cmds)
 		return (0);
 	}
 	settings = 0;
-	words = ft_split(cmds->current->full_args, ' ');
+	words = cmds->current->phrase_parsed;
 	filter_words = set_echo_settings(words, &settings);
 	exit_code = echo_exec_print(cmds, settings, filter_words);
 	cmds->exit_code.code = exit_code;

--- a/srcs/builtins/echo_utils.c
+++ b/srcs/builtins/echo_utils.c
@@ -83,7 +83,7 @@ int	echo_exec_print(t_cmds *cmds, int settings, char **words)
 	char	*word;
 	int		exit_code;
 
-	i = 0;
+	i = 1;
 	exit_code = 0;
 	while (words[i] != NULL)
 	{

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -37,7 +37,7 @@ int	check_errors_exit(const char *arg, int count)
 	}
 	if (arg[0] != '-' && ft_isdigit(arg[0]) == 0)
 	{
-		ft_printf("minishell: exit: %s: numeric argument required\n", arg);
+		ft_printf("[1] minishell: exit: %s: numeric argument required\n", arg);
 		return (2);
 	}
 	if (arg[0] == '-' && ft_isdigit(arg[1]) == 1)

--- a/srcs/commands/exec_builtin_cmd.c
+++ b/srcs/commands/exec_builtin_cmd.c
@@ -14,15 +14,7 @@
 
 void	free_builtin_cmd(t_cmds *cmds)
 {
-	int	i;
-
-	i = 0;
-	while (cmds->envs[i])
-	{
-		free(cmds->envs[i]);
-		i++;
-	}
-	free(cmds->envs);
+	free_arr(cmds->envs);
 	free_cmd_nodes(cmds->cmd_list);
 	free_commands(cmds);
 }

--- a/srcs/commands/exec_external_cmd.c
+++ b/srcs/commands/exec_external_cmd.c
@@ -28,7 +28,7 @@ void	exec_external(t_cmds *cmds)
 			perror("fork");
 		if (pid == 0)
 		{
-			execve(path, cmds->current->split_args, cmds->envs);
+			execve(path, cmds->current->phrase_parsed, cmds->envs);
 			perror("execve");
 		}
 		if (pid > 0)

--- a/srcs/commands/interpreter.c
+++ b/srcs/commands/interpreter.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   interpreter.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: caalbert <caalbert@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/02/18 02:55:02 by antthoma          #+#    #+#             */
+/*   Updated: 2023/06/06 10:21:31 by caalbert         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	ft_count_arr(char **arr)
+{
+	int	i;
+
+	i = 0;
+	while (arr[i] != NULL)
+		i++;
+	return (i);
+}
+
+void	ft_free_arr(char **arr)
+{
+	char	**ptr;
+
+	if (arr == NULL)
+		return ;
+	ptr = arr;
+	while (*ptr != NULL)
+	{
+		free(*ptr);
+		ptr++;
+	}
+	free(arr);
+}
+
+void	parse_values_args(t_cmds *cmds)
+{
+	char	**original_args;
+	char	**args_ptr;
+	int		i;
+
+	original_args = ft_split(cmds->current->phrase, ' ');
+	cmds->current->phrase_parsed = ft_calloc(sizeof(char *),
+			ft_count_arr(original_args) + 1);
+	i = 0;
+	args_ptr = original_args;
+	while (*args_ptr != NULL)
+	{
+		if (strcmp(*args_ptr, "$PWD") == 0)
+		{
+			if (getenv("PWD") != NULL)
+				cmds->current->phrase_parsed[i] = ft_strdup(getenv("PWD"));
+		}
+		else if (strcmp(*args_ptr, "$?") == 0)
+			cmds->current->phrase_parsed[i] = ft_itoa(cmds->exit_code.code);
+		else
+			cmds->current->phrase_parsed[i] = ft_strdup(*args_ptr);
+		args_ptr++;
+		i++;
+	}
+	ft_free_arr(original_args);
+}
+
+void	init_interpreter(t_cmds *cmds)
+{
+	parse_values_args(cmds);
+}

--- a/srcs/commands/nodes.c
+++ b/srcs/commands/nodes.c
@@ -35,6 +35,7 @@ void	run_node(t_cmds *cmds)
 	type_command = -1;
 	if (ft_strcmp(cmds->current->type, "WORD") == 0)
 	{
+		init_interpreter(cmds);
 		type_command = check_type_command(cmds);
 		if (type_command == 0)
 			exec_builtin(cmds);
@@ -45,5 +46,6 @@ void	run_node(t_cmds *cmds)
 			printf("minishell: %s: command not found\n", cmds->input->cmd_name);
 			cmds->exit_code.code = 127;
 		}
+		free_arr(cmds->current->phrase_parsed);
 	}
 }


### PR DESCRIPTION
Return value of a process
Execute a simple command with an absolute path like /bin/ls, or any other command with arguments

- [x]  /bin/ls
- [x]  which mkdir
- [x]  /usr/bin/mkdir

but without any quotes and double quotes. Then execute echo $?
Check the printed value. You can do the same in bash in order to compare the results.
Repeat multiple times with different commands and arguments. Try some wrong commands like '/bin/ls filethatdoesntexist'

- [x]  '/bin/ls filethatdoesntexist'
- [x]  expr $? + $?
- [x]  Leaks