### PR TITLE
fix: solve leak in free envs when not exist

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -75,7 +75,6 @@ typedef struct s_exit_code
 {
 	int		code;
 	char	*msg;
-	char	*last_cmd;
 }	t_exit_code;
 
 /* Read Keyboard command and arguments */

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -61,7 +61,6 @@ int	exit_adapter(t_cmds *cmds)
 
 	cmds->signal_exit = 1;
 	printf("exit\n");
-	cmds->exit_code.last_cmd = ft_strdup("exit");
 	if (cmds->current->phrase_parsed == NULL)
 		return (0);
 	count = count_args(cmds->current->phrase_parsed[1]);

--- a/srcs/commands/commands.c
+++ b/srcs/commands/commands.c
@@ -28,7 +28,6 @@ void	find_command(t_cmds *cmds)
 	}
 	ft_printf("minishell: %s: command not found\n", cmds->input->cmd_name);
 	cmds->exit_code.code = 127;
-	cmds->exit_code.last_cmd = cmds->input->cmd_name;
 	cmds->cmd_finded->name = NULL;
 }
 

--- a/srcs/envs/envs.c
+++ b/srcs/envs/envs.c
@@ -42,6 +42,8 @@ void	free_envs(t_cmds *cmds)
 	int	i;
 
 	i = 0;
+	if (cmds->envs == NULL)
+		return ;
 	while (cmds->envs[i] != NULL)
 	{
 		free(cmds->envs[i]);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -17,7 +17,6 @@ void	free_commands(t_cmds *cmds)
 	if (cmds->input->datacpy != NULL)
 		free(cmds->input->datacpy);
 	free(cmds->input);
-	free(cmds->exit_code.last_cmd);
 	free(cmds->arr_cmds);
 	free(cmds->cmd_finded);
 	free(cmds);
@@ -68,7 +67,6 @@ int	main(int argc, char **argv, char **envp)
 	cmds->input = ft_calloc(1, sizeof(t_input));
 	cmds->cmd_finded = ft_calloc(1, sizeof(t_command));
 	cmds->exit_code.code = 0;
-	cmds->exit_code.last_cmd = NULL;
 	cmds->signal_exit = -1;
 	cmds->envs = ft_calloc(count_envp(envp) + 2, sizeof(char *));
 	cmds->has_quote = 0;

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -5,37 +5,37 @@ function tests() {
   make debug >> /dev/null
 
 
-  COMMAND="exit1"
+  export COMMAND="exit1"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
 exit
 EOF
 
-  COMMAND="exit1"
+  export COMMAND="exit2"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
 exit
-EOF
-
-  COMMAND="exit2"
-  echo $COMMAND
-  valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
-exit 1
 EOF
 
   export COMMAND="exit3"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
-exit  $PWD
+exit 1
 EOF
 
   export COMMAND="exit4"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
-exit a
+exit  $PWD
 EOF
 
   export COMMAND="exit5"
+  echo $COMMAND
+  valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
+exit a
+EOF
+
+  export COMMAND="exit6"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
 mkdir p


### PR DESCRIPTION
==8599== 5 bytes in 1 blocks are still reachable in loss record 2 of 76
==8599==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==8599==    by 0x10D70E: ft_strdup (in /app/srcs/minishell)
==8599==    by 0x10B45E: exit_adapter (exit.c:64)
==8599==    by 0x10A99A: exec_builtin (exec_builtin_cmd.c:61)
==8599==    by 0x10A427: run_node (nodes.c:41)