### PR TITLE
fix: leak solve removing ft_split

### DIFF
--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -42,7 +42,7 @@ int	set_env_var(t_cmds *cmds, char *key, char *value)
 {
 	char	**envs;
 	char	*new_key;
-	char 	*key_and_value;
+	char	*key_and_value;
 
 	if (cmds->envs == NULL)
 		return (1);

--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -12,7 +12,7 @@
 
 #include "../../includes/minishell.h"
 
-void	save_envs(t_cmds *cmds, char **envs, char *key, char *new_key_value)
+void	save_envs(t_cmds *cmds, char **envs, char *key, char *key_and_value)
 {
 	int	trigger;
 	int	i;
@@ -23,7 +23,7 @@ void	save_envs(t_cmds *cmds, char **envs, char *key, char *new_key_value)
 	{
 		if (ft_strncmp(cmds->envs[i], key, ft_strlen(key)) == 0)
 		{
-			envs[i] = ft_strdup(new_key_value);
+			envs[i] = ft_strdup(key_and_value);
 			trigger = 1;
 		}
 		else
@@ -32,7 +32,7 @@ void	save_envs(t_cmds *cmds, char **envs, char *key, char *new_key_value)
 	}
 	if (trigger == 0)
 	{
-		envs[i] = ft_strdup(new_key_value);
+		envs[i] = ft_strdup(key_and_value);
 		i++;
 	}
 	envs[i] = NULL;
@@ -41,14 +41,17 @@ void	save_envs(t_cmds *cmds, char **envs, char *key, char *new_key_value)
 int	set_env_var(t_cmds *cmds, char *key, char *value)
 {
 	char	**envs;
-	char	*new_key_value;
+	char	*new_key;
+	char 	*key_and_value;
 
 	if (cmds->envs == NULL)
 		return (1);
 	envs = ft_calloc(count_arr(cmds->envs) + 2, sizeof(char *));
-	new_key_value = ft_strjoin(key, "=");
-	new_key_value = ft_strjoin(new_key_value, value);
-	save_envs(cmds, envs, key, new_key_value);
+	new_key = ft_strjoin(key, "=");
+	key_and_value = ft_strjoin(new_key, value);
+	save_envs(cmds, envs, key, key_and_value);
+	free(new_key);
+	free(key_and_value);
 	free_arr(cmds->envs);
 	cmds->envs = envs;
 	return (0);
@@ -59,8 +62,6 @@ int	export_adapter(t_cmds *cmds)
 	char	**args;
 	char	**env;
 	int		result;
-	char	*value;
-	char	*key;
 
 	env = cmds->envs;
 	if (cmds->current->full_args == NULL)
@@ -72,11 +73,8 @@ int	export_adapter(t_cmds *cmds)
 		}
 		return (0);
 	}
-	args = ft_split(cmds->current->full_args, '=');
-	args[1] = remove_string(args[1], '"');
-	key = args[0];
-	value = args[1];
-	result = set_env_var(cmds, key, value);
+	args = ft_split(cmds->current->phrase_parsed[1], '=');
+	result = set_env_var(cmds, args[0], args[1]);
 	free_arr(args);
 	return (result);
 }

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -4,7 +4,6 @@ function tests() {
   echo "Start Unit Commands Tests"
   make debug >> /dev/null
 
-
   export COMMAND="exit1"
   echo $COMMAND
   valgrind --quiet --leak-check=full --show-leak-kinds=all --track-origins=yes --suppressions=readline.supp srcs/minishell > valgrind_output_${COMMAND}.log 2>&1 << EOF
@@ -205,14 +204,13 @@ function reportTests() {
   deleteTests
   tests
   for FILE in valgrind_output_*; do
-    result=$(cat $FILE | grep at -a2 | wc -l)
+    result=$(cat $FILE | grep -e ' at ' -a2 | wc -l)
     if [ $result -gt 0 ]; then
       echo file ${FILE} has ${result} errors >> report.log
     else
       echo file ${FILE} has no errors
       rm -rf ${FILE}
     fi
-
   done
   ReportMove
 }


### PR DESCRIPTION
**When run:**
export NAME="Antonio"
exit

**Error:**
==10780== 6 bytes in 1 blocks are definitely lost in loss record 3 of 69
==10780==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==10780==    by 0x10D786: ft_strjoin (in /app/srcs/minishell)
==10780==    by 0x10B656: set_env_var (export.c:49)
==10780==    by 0x10B774: export_adapter (export.c:79)
==10780==    by 0x10A96B: exec_builtin (exec_builtin_cmd.c:61)
==10780==    by 0x10A3F8: run_node (nodes.c:41)
==10780==    by 0x109FF5: execute_cmd (commands.c:68)
==10780==    by 0x10958B: minishell (main.c:51)
==10780==    by 0x1096A5: main (main.c:76)