### PR TITLE
fix: add if to stop when artgs empty

### DIFF
--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -74,6 +74,12 @@ int	export_adapter(t_cmds *cmds)
 		return (0);
 	}
 	args = ft_split(cmds->current->phrase_parsed[1], '=');
+	if (args[0] == NULL || args[1] == NULL)
+	{
+		printf("minishell: export: `%s': not a valid identifier\n", args[0]);
+		free_arr(args);
+		return (1);
+	}
 	result = set_env_var(cmds, args[0], args[1]);
 	free_arr(args);
 	return (result);

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -192,6 +192,7 @@ EOF
 function deleteTests() {
   rm -rf valgrind_output_*
   rm -rf reports
+  rm -rf report.log
 }
 
 function ReportMove() {


### PR DESCRIPTION
**When run:**
export NAME

**Solved:**
	args = ft_split(cmds->current->phrase_parsed[1], '=');
	if (args[0] == NULL || args[1] == NULL)
	{
		printf("minishell: export: `%s': not a valid identifier\n", args[0]);
		free_arr(args);
		return (1);
	}

**Error:**
==11980== Invalid read of size 1
==11980==    at 0x10D8FE: ft_strlen (in /app/srcs/minishell)
==11980==    by 0x10D6B2: ft_strdup (in /app/srcs/minishell)
==11980==    by 0x10B5C2: save_envs (export.c:35)
==11980==    by 0x10B689: set_env_var (export.c:52)
==11980==    by 0x10B75F: export_adapter (export.c:77)
==11980==    by 0x10A96B: exec_builtin (exec_builtin_cmd.c:61)
==11980==    by 0x10A3F8: run_node (nodes.c:41)
==11980==    by 0x109FF5: execute_cmd (commands.c:68)
==11980==    by 0x10958B: minishell (main.c:51)
==11980==    by 0x1096A5: main (main.c:76)
==11980==  Address 0x0 is not stack'd, malloc'd or (recently) free'd