### PR TITLE
fix: add checker if env is null

### DIFF
--- a/srcs/builtins/unset.c
+++ b/srcs/builtins/unset.c
@@ -52,6 +52,8 @@ int	clean_envs(t_cmds *cmds)
 	int	i;
 
 	i = 0;
+	if (cmds->envs == NULL)
+		return (1);
 	while (cmds->envs[i] != NULL)
 	{
 		free(cmds->envs[i]);


### PR DESCRIPTION
**When run:**
unset
unset

**Solved:**
	if (cmds->envs == NULL)
		return (1);

**Error:**
==14250== Invalid read of size 8
==14250==    at 0x10BA66: clean_envs (unset.c:55)
==14250==    by 0x10BAC4: unset_adapter (unset.c:71)
==14250==    by 0x10A975: exec_builtin (exec_builtin_cmd.c:61)
==14250==    by 0x10A402: run_node (nodes.c:41)
==14250==    by 0x109FFF: execute_cmd (commands.c:68)
==14250==    by 0x10958B: minishell (main.c:51)
==14250==    by 0x1096A5: main (main.c:76)
==14250==  Address 0x0 is not stack'd, malloc'd or (recently) free'd